### PR TITLE
Spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ overwrite existing records.  Instead an error is returned to the caller forcing
 a decision on how to handle.
 
 At this time, Cloudflare provides *no guarantees* about the stability of this
-pacakge.  Please use vendoring to maintain this dependency in your project.
+package.  Please use vendoring to maintain this dependency in your project.

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -265,7 +265,7 @@ func TestHelpers(t *testing.T) {
 		t.Errorf("metadata structs do not match. expect: %v, actual: %v", c.expect, m)
 	}
 	if b.Size() != int(m.size) {
-		t.Errorf("Reported size does not match meatadata")
+		t.Errorf("Reported size does not match metadata")
 	}
 	os.Remove(filename)
 }


### PR DESCRIPTION
Generated by https://github.com/jsoref/spelling `f`; to maintain your repo, please consider `fchurn`